### PR TITLE
Add 'device' option to configure audio output

### DIFF
--- a/index.js
+++ b/index.js
@@ -57,7 +57,8 @@ module.exports = function (buffer, how, cb) {
 	});
 	let write = AudioSpeaker({
 		channels: buffer.numberOfChannels,
-		sampleRate: buffer.sampleRate
+		sampleRate: buffer.sampleRate,
+		device: how.device
 	});
 
 	//provide API

--- a/readme.md
+++ b/readme.md
@@ -36,6 +36,9 @@ let pause = play(audioBuffer, {
   //volume
   volume: 1,
 
+  //device (for use with NodeJS, optional)
+  device: 'hw:1,0',
+
   //possibly existing audio-context, not necessary
   context: require('audio-context'),
 


### PR DESCRIPTION
This adds the possibility of specifying the audio device for output. (Solves Issue #24)

For example:
```
let pause = play(audioBuffer, {
  // output device
  device: 'hw:1,0'
}
```

Explanation:
node-speaker already supports this option, so it just needs to be propagated, which is done by adding 1 line to index.js
